### PR TITLE
Adding a Database (Postgres)

### DIFF
--- a/bot.ts
+++ b/bot.ts
@@ -1,10 +1,23 @@
-// Dependencies
-const DotEnv = require("dotenv").config({path: `${__dirname}/.env`});
-const cron = require("cron");
-const aws = require(__dirname + "/src/awsUtils");
+// Node Modules
+import * as cron from "cron";
+import * as dotenv from "dotenv";
+import { Client, Intents, Guild, GuildBasedChannel } from "discord.js";
 
-// Discord client instance
-const { Client, Intents } = require('discord.js');
+// Custom Scripts
+import { connectDB } from "./src/databaseUtils";
+import * as aws from "./src/awsUtils";
+
+/* ============================================ */
+/* SETUP                                        */
+/* ============================================ */
+
+// Load the .env environment variables 
+dotenv.config({path: `.env`});
+
+// Connect to the database
+connectDB();
+
+// Discord Client
 const client = new Client({ intents: [
     Intents.FLAGS.GUILDS,                   // Access servers
     Intents.FLAGS.GUILD_MESSAGES,           // Send message to servers
@@ -16,9 +29,9 @@ const client = new Client({ intents: [
 // SERVER SELECTORS
 // =================================================================
 
-let devServer
+let devServer: Guild
 let devServer_general
-let nubuSquad
+let nubuSquad: Guild
 let nubuSquad_nubs
 
 // =================================================================
@@ -57,7 +70,6 @@ let cmd_regex = /!.+ (.+)$/gm;
 
 // Event: Logs when bot has successfully logged in
 client.on("ready", function () {
-    console.log(`Logged in as ${client.user.tag}!`);
 
     // SERVER SELECTORS =======================
 

--- a/database/init_bot.sql
+++ b/database/init_bot.sql
@@ -1,0 +1,13 @@
+-- Bot Info Table Structure
+
+CREATE TABLE
+    IF NOT EXISTS bot_info (
+        id VARCHAR(50) PRIMARY KEY,
+        is_online BOOLEAN DEFAULT true NOT NULL
+    );
+
+-- Populate Bot Info Table
+
+INSERT INTO
+    bot_info (id, is_online)
+VALUES ('automation_bot', true);

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -6,6 +6,28 @@ services:
     image: discord-bot:latest
     container_name: discord-bot
     restart: always
+    networks:
+      - discord-bot
+    depends_on:
+      - postgres
     volumes:
       - ./:/usr/src                       # Mount the current directory to workdir of the container
       - /usr/src/node_modules             # Prevent the internal node_modules from being deleted when no "node_modules" folder exists in the root directory 
+  
+  postgres:
+    image: postgres:14.5
+    container_name: postgres
+    ports:
+      - "5432:5432"
+    environment:
+      POSTGRES_USER: ${DB_USER}
+      POSTGRES_DB: ${DB_NAME}
+      POSTGRES_PASSWORD: ${DB_PASS}
+    volumes:
+      - ./database:/docker-entrypoint-initdb.d
+    networks:
+      - discord-bot
+
+networks:
+  discord-bot: 
+    driver: bridge

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,13 +13,16 @@
         "discord.js": "^13.5.1",
         "dotenv": "^11.0.0",
         "lodash": "^4.17.21",
+        "pg": "^8.8.0",
         "ssh2": "^1.5.0",
         "ssh2-promise": "^1.0.3"
       },
       "devDependencies": {
         "@testing-library/jest-dom": "^5.16.5",
+        "@types/cron": "^2.0.0",
         "@types/jest": "^29.2.0",
         "@types/node": "^18.11.7",
+        "@types/pg": "^8.6.5",
         "@types/ssh2": "^1.11.6",
         "jest": "^29.2.2",
         "jest-environment-jsdom": "^29.2.2",
@@ -1204,6 +1207,16 @@
         "@babel/types": "^7.3.0"
       }
     },
+    "node_modules/@types/cron": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@types/cron/-/cron-2.0.0.tgz",
+      "integrity": "sha512-xZM08fqvwIXgghtPVkSPKNgC+JoMQ2OHazEvyTKnNf7aWu1aB6/4lBbQFrb03Td2cUGG7ITzMv3mFYnMu6xRaQ==",
+      "dev": true,
+      "dependencies": {
+        "@types/luxon": "*",
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/graceful-fs": {
       "version": "4.1.5",
       "resolved": "https://registry.npmjs.org/@types/graceful-fs/-/graceful-fs-4.1.5.tgz",
@@ -1258,6 +1271,12 @@
         "parse5": "^7.0.0"
       }
     },
+    "node_modules/@types/luxon": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/luxon/-/luxon-3.0.2.tgz",
+      "integrity": "sha512-HM2OVWckUMmXbWYZufmWT2XMURGDZ6XbyNyQ+Lx+gCFGFqbZaIjsz7b+AGeGP/AuVYHBiuGY+wXfweP1RremnA==",
+      "dev": true
+    },
     "node_modules/@types/node": {
       "version": "18.11.7",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-18.11.7.tgz",
@@ -1283,6 +1302,17 @@
       },
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/@types/pg": {
+      "version": "8.6.5",
+      "resolved": "https://registry.npmjs.org/@types/pg/-/pg-8.6.5.tgz",
+      "integrity": "sha512-tOkGtAqRVkHa/PVZicq67zuujI4Oorfglsr2IbKofDwBSysnaqSx7W1mDqFqdkGE6Fbgh+PZAl0r/BWON/mozw==",
+      "dev": true,
+      "dependencies": {
+        "@types/node": "*",
+        "pg-protocol": "*",
+        "pg-types": "^2.2.0"
       }
     },
     "node_modules/@types/prettier": {
@@ -1711,6 +1741,14 @@
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
       "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
       "dev": true
+    },
+    "node_modules/buffer-writer": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/buffer-writer/-/buffer-writer-2.0.0.tgz",
+      "integrity": "sha512-a7ZpuTZU1TRtnwyCNW3I5dc0wWNC3VR9S++Ewyk2HHZdrO3CQJqSpd+95Us590V6AL7JqUAH2IwZ/398PmNFgw==",
+      "engines": {
+        "node": ">=4"
+      }
     },
     "node_modules/buildcheck": {
       "version": "0.0.3",
@@ -4417,6 +4455,11 @@
         "node": ">=6"
       }
     },
+    "node_modules/packet-reader": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/packet-reader/-/packet-reader-1.0.0.tgz",
+      "integrity": "sha512-HAKu/fG3HpHFO0AA8WE8q2g+gBJaZ9MG7fcKk+IJPLTGAD6Psw4443l+9DGRbOIh3/aXr7Phy0TjilYivJo5XQ=="
+    },
     "node_modules/parse-json": {
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.2.0.tgz",
@@ -4480,6 +4523,80 @@
       "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
       "dev": true
     },
+    "node_modules/pg": {
+      "version": "8.8.0",
+      "resolved": "https://registry.npmjs.org/pg/-/pg-8.8.0.tgz",
+      "integrity": "sha512-UXYN0ziKj+AeNNP7VDMwrehpACThH7LUl/p8TDFpEUuSejCUIwGSfxpHsPvtM6/WXFy6SU4E5RG4IJV/TZAGjw==",
+      "dependencies": {
+        "buffer-writer": "2.0.0",
+        "packet-reader": "1.0.0",
+        "pg-connection-string": "^2.5.0",
+        "pg-pool": "^3.5.2",
+        "pg-protocol": "^1.5.0",
+        "pg-types": "^2.1.0",
+        "pgpass": "1.x"
+      },
+      "engines": {
+        "node": ">= 8.0.0"
+      },
+      "peerDependencies": {
+        "pg-native": ">=3.0.1"
+      },
+      "peerDependenciesMeta": {
+        "pg-native": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/pg-connection-string": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/pg-connection-string/-/pg-connection-string-2.5.0.tgz",
+      "integrity": "sha512-r5o/V/ORTA6TmUnyWZR9nCj1klXCO2CEKNRlVuJptZe85QuhFayC7WeMic7ndayT5IRIR0S0xFxFi2ousartlQ=="
+    },
+    "node_modules/pg-int8": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/pg-int8/-/pg-int8-1.0.1.tgz",
+      "integrity": "sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw==",
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/pg-pool": {
+      "version": "3.5.2",
+      "resolved": "https://registry.npmjs.org/pg-pool/-/pg-pool-3.5.2.tgz",
+      "integrity": "sha512-His3Fh17Z4eg7oANLob6ZvH8xIVen3phEZh2QuyrIl4dQSDVEabNducv6ysROKpDNPSD+12tONZVWfSgMvDD9w==",
+      "peerDependencies": {
+        "pg": ">=8.0"
+      }
+    },
+    "node_modules/pg-protocol": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/pg-protocol/-/pg-protocol-1.5.0.tgz",
+      "integrity": "sha512-muRttij7H8TqRNu/DxrAJQITO4Ac7RmX3Klyr/9mJEOBeIpgnF8f9jAfRz5d3XwQZl5qBjF9gLsUtMPJE0vezQ=="
+    },
+    "node_modules/pg-types": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/pg-types/-/pg-types-2.2.0.tgz",
+      "integrity": "sha512-qTAAlrEsl8s4OiEQY69wDvcMIdQN6wdz5ojQiOy6YRMuynxenON0O5oCpJI6lshc6scgAY8qvJ2On/p+CXY0GA==",
+      "dependencies": {
+        "pg-int8": "1.0.1",
+        "postgres-array": "~2.0.0",
+        "postgres-bytea": "~1.0.0",
+        "postgres-date": "~1.0.4",
+        "postgres-interval": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/pgpass": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/pgpass/-/pgpass-1.0.5.tgz",
+      "integrity": "sha512-FdW9r/jQZhSeohs1Z3sI1yxFQNFvMcnmfuj4WBMUTxOrAyLMaTcE1aAMBiTlbMNaXvBCQuVi0R7hd8udDSP7ug==",
+      "dependencies": {
+        "split2": "^4.1.0"
+      }
+    },
     "node_modules/picocolors": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.0.tgz",
@@ -4517,6 +4634,41 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/postgres-array": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/postgres-array/-/postgres-array-2.0.0.tgz",
+      "integrity": "sha512-VpZrUqU5A69eQyW2c5CA1jtLecCsN2U/bD6VilrFDWq5+5UIEVO7nazS3TEcHf1zuPYO/sqGvUvW62g86RXZuA==",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/postgres-bytea": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/postgres-bytea/-/postgres-bytea-1.0.0.tgz",
+      "integrity": "sha512-xy3pmLuQqRBZBXDULy7KbaitYqLcmxigw14Q5sj8QBVLqEwXfeybIKVWiqAXTlcvdvb0+xkOtDbfQMOf4lST1w==",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/postgres-date": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/postgres-date/-/postgres-date-1.0.7.tgz",
+      "integrity": "sha512-suDmjLVQg78nMK2UZ454hAG+OAW+HQPZ6n++TNDUX+L0+uUlLywnoxJKDou51Zm+zTCjrCl0Nq6J9C5hP9vK/Q==",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/postgres-interval": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/postgres-interval/-/postgres-interval-1.2.0.tgz",
+      "integrity": "sha512-9ZhXKM/rw350N1ovuWHbGxnGh/SNJ4cnxHiM0rxE4VN41wsg8P8zWn9hv/buK00RP4WvlOyr/RBDiptyxVbkZQ==",
+      "dependencies": {
+        "xtend": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/prelude-ls": {
@@ -4815,6 +4967,14 @@
       "dependencies": {
         "buffer-from": "^1.0.0",
         "source-map": "^0.6.0"
+      }
+    },
+    "node_modules/split2": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/split2/-/split2-4.1.0.tgz",
+      "integrity": "sha512-VBiJxFkxiXRlUIeyMQi8s4hgvKCSjtknJv/LVYbrgALPwf5zSKmEwV9Lst25AkvMDnvxODugjdl6KZgwKM1WYQ==",
+      "engines": {
+        "node": ">= 10.x"
       }
     },
     "node_modules/sprintf-js": {
@@ -5500,6 +5660,14 @@
       "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
       "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
       "dev": true
+    },
+    "node_modules/xtend": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
+      "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
+      "engines": {
+        "node": ">=0.4"
+      }
     },
     "node_modules/y18n": {
       "version": "5.0.8",
@@ -6504,6 +6672,16 @@
         "@babel/types": "^7.3.0"
       }
     },
+    "@types/cron": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@types/cron/-/cron-2.0.0.tgz",
+      "integrity": "sha512-xZM08fqvwIXgghtPVkSPKNgC+JoMQ2OHazEvyTKnNf7aWu1aB6/4lBbQFrb03Td2cUGG7ITzMv3mFYnMu6xRaQ==",
+      "dev": true,
+      "requires": {
+        "@types/luxon": "*",
+        "@types/node": "*"
+      }
+    },
     "@types/graceful-fs": {
       "version": "4.1.5",
       "resolved": "https://registry.npmjs.org/@types/graceful-fs/-/graceful-fs-4.1.5.tgz",
@@ -6558,6 +6736,12 @@
         "parse5": "^7.0.0"
       }
     },
+    "@types/luxon": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/luxon/-/luxon-3.0.2.tgz",
+      "integrity": "sha512-HM2OVWckUMmXbWYZufmWT2XMURGDZ6XbyNyQ+Lx+gCFGFqbZaIjsz7b+AGeGP/AuVYHBiuGY+wXfweP1RremnA==",
+      "dev": true
+    },
     "@types/node": {
       "version": "18.11.7",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-18.11.7.tgz",
@@ -6582,6 +6766,17 @@
             "mime-types": "^2.1.12"
           }
         }
+      }
+    },
+    "@types/pg": {
+      "version": "8.6.5",
+      "resolved": "https://registry.npmjs.org/@types/pg/-/pg-8.6.5.tgz",
+      "integrity": "sha512-tOkGtAqRVkHa/PVZicq67zuujI4Oorfglsr2IbKofDwBSysnaqSx7W1mDqFqdkGE6Fbgh+PZAl0r/BWON/mozw==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*",
+        "pg-protocol": "*",
+        "pg-types": "^2.2.0"
       }
     },
     "@types/prettier": {
@@ -6917,6 +7112,11 @@
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
       "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
       "dev": true
+    },
+    "buffer-writer": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/buffer-writer/-/buffer-writer-2.0.0.tgz",
+      "integrity": "sha512-a7ZpuTZU1TRtnwyCNW3I5dc0wWNC3VR9S++Ewyk2HHZdrO3CQJqSpd+95Us590V6AL7JqUAH2IwZ/398PmNFgw=="
     },
     "buildcheck": {
       "version": "0.0.3",
@@ -8928,6 +9128,11 @@
       "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
       "dev": true
     },
+    "packet-reader": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/packet-reader/-/packet-reader-1.0.0.tgz",
+      "integrity": "sha512-HAKu/fG3HpHFO0AA8WE8q2g+gBJaZ9MG7fcKk+IJPLTGAD6Psw4443l+9DGRbOIh3/aXr7Phy0TjilYivJo5XQ=="
+    },
     "parse-json": {
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.2.0.tgz",
@@ -8973,6 +9178,61 @@
       "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
       "dev": true
     },
+    "pg": {
+      "version": "8.8.0",
+      "resolved": "https://registry.npmjs.org/pg/-/pg-8.8.0.tgz",
+      "integrity": "sha512-UXYN0ziKj+AeNNP7VDMwrehpACThH7LUl/p8TDFpEUuSejCUIwGSfxpHsPvtM6/WXFy6SU4E5RG4IJV/TZAGjw==",
+      "requires": {
+        "buffer-writer": "2.0.0",
+        "packet-reader": "1.0.0",
+        "pg-connection-string": "^2.5.0",
+        "pg-pool": "^3.5.2",
+        "pg-protocol": "^1.5.0",
+        "pg-types": "^2.1.0",
+        "pgpass": "1.x"
+      }
+    },
+    "pg-connection-string": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/pg-connection-string/-/pg-connection-string-2.5.0.tgz",
+      "integrity": "sha512-r5o/V/ORTA6TmUnyWZR9nCj1klXCO2CEKNRlVuJptZe85QuhFayC7WeMic7ndayT5IRIR0S0xFxFi2ousartlQ=="
+    },
+    "pg-int8": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/pg-int8/-/pg-int8-1.0.1.tgz",
+      "integrity": "sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw=="
+    },
+    "pg-pool": {
+      "version": "3.5.2",
+      "resolved": "https://registry.npmjs.org/pg-pool/-/pg-pool-3.5.2.tgz",
+      "integrity": "sha512-His3Fh17Z4eg7oANLob6ZvH8xIVen3phEZh2QuyrIl4dQSDVEabNducv6ysROKpDNPSD+12tONZVWfSgMvDD9w==",
+      "requires": {}
+    },
+    "pg-protocol": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/pg-protocol/-/pg-protocol-1.5.0.tgz",
+      "integrity": "sha512-muRttij7H8TqRNu/DxrAJQITO4Ac7RmX3Klyr/9mJEOBeIpgnF8f9jAfRz5d3XwQZl5qBjF9gLsUtMPJE0vezQ=="
+    },
+    "pg-types": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/pg-types/-/pg-types-2.2.0.tgz",
+      "integrity": "sha512-qTAAlrEsl8s4OiEQY69wDvcMIdQN6wdz5ojQiOy6YRMuynxenON0O5oCpJI6lshc6scgAY8qvJ2On/p+CXY0GA==",
+      "requires": {
+        "pg-int8": "1.0.1",
+        "postgres-array": "~2.0.0",
+        "postgres-bytea": "~1.0.0",
+        "postgres-date": "~1.0.4",
+        "postgres-interval": "^1.1.0"
+      }
+    },
+    "pgpass": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/pgpass/-/pgpass-1.0.5.tgz",
+      "integrity": "sha512-FdW9r/jQZhSeohs1Z3sI1yxFQNFvMcnmfuj4WBMUTxOrAyLMaTcE1aAMBiTlbMNaXvBCQuVi0R7hd8udDSP7ug==",
+      "requires": {
+        "split2": "^4.1.0"
+      }
+    },
     "picocolors": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.0.tgz",
@@ -8998,6 +9258,29 @@
       "dev": true,
       "requires": {
         "find-up": "^4.0.0"
+      }
+    },
+    "postgres-array": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/postgres-array/-/postgres-array-2.0.0.tgz",
+      "integrity": "sha512-VpZrUqU5A69eQyW2c5CA1jtLecCsN2U/bD6VilrFDWq5+5UIEVO7nazS3TEcHf1zuPYO/sqGvUvW62g86RXZuA=="
+    },
+    "postgres-bytea": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/postgres-bytea/-/postgres-bytea-1.0.0.tgz",
+      "integrity": "sha512-xy3pmLuQqRBZBXDULy7KbaitYqLcmxigw14Q5sj8QBVLqEwXfeybIKVWiqAXTlcvdvb0+xkOtDbfQMOf4lST1w=="
+    },
+    "postgres-date": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/postgres-date/-/postgres-date-1.0.7.tgz",
+      "integrity": "sha512-suDmjLVQg78nMK2UZ454hAG+OAW+HQPZ6n++TNDUX+L0+uUlLywnoxJKDou51Zm+zTCjrCl0Nq6J9C5hP9vK/Q=="
+    },
+    "postgres-interval": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/postgres-interval/-/postgres-interval-1.2.0.tgz",
+      "integrity": "sha512-9ZhXKM/rw350N1ovuWHbGxnGh/SNJ4cnxHiM0rxE4VN41wsg8P8zWn9hv/buK00RP4WvlOyr/RBDiptyxVbkZQ==",
+      "requires": {
+        "xtend": "^4.0.0"
       }
     },
     "prelude-ls": {
@@ -9229,6 +9512,11 @@
         "buffer-from": "^1.0.0",
         "source-map": "^0.6.0"
       }
+    },
+    "split2": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/split2/-/split2-4.1.0.tgz",
+      "integrity": "sha512-VBiJxFkxiXRlUIeyMQi8s4hgvKCSjtknJv/LVYbrgALPwf5zSKmEwV9Lst25AkvMDnvxODugjdl6KZgwKM1WYQ=="
     },
     "sprintf-js": {
       "version": "1.0.3",
@@ -9725,6 +10013,11 @@
       "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
       "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
       "dev": true
+    },
+    "xtend": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
+      "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ=="
     },
     "y18n": {
       "version": "5.0.8",

--- a/package.json
+++ b/package.json
@@ -13,13 +13,16 @@
     "discord.js": "^13.5.1",
     "dotenv": "^11.0.0",
     "lodash": "^4.17.21",
+    "pg": "^8.8.0",
     "ssh2": "^1.5.0",
     "ssh2-promise": "^1.0.3"
   },
   "devDependencies": {
     "@testing-library/jest-dom": "^5.16.5",
+    "@types/cron": "^2.0.0",
     "@types/jest": "^29.2.0",
     "@types/node": "^18.11.7",
+    "@types/pg": "^8.6.5",
     "@types/ssh2": "^1.11.6",
     "jest": "^29.2.2",
     "jest-environment-jsdom": "^29.2.2",

--- a/src/awsUtils.ts
+++ b/src/awsUtils.ts
@@ -1,19 +1,25 @@
-// Dependencies
+// Node Modules 
+import { config as AWSConfig, EC2 } from "aws-sdk";
+import { readFileSync } from "fs";
+import { Client as sshClient } from "ssh2";
+// import * as SSH2Promise from "ssh2-promise";
+
+// Custom Scripts
 import { EC2Instance } from "./customTypes";
-const AWS = require('aws-sdk');
-const { readFileSync } = require('fs');
-const { Client: sshClient } = require('ssh2');
-const SSH2Promise = require('ssh2-promise');
+
+/* ============================================ */
+/* SETUP                                        */
+/* ============================================ */
 
 // SSH Promise (SSH2 Promise Wrapper)
 // var ssh = new SSH2Promise(sshconfig);
 
 // AWS Setup
 // Set the AWS region 
-AWS.config.update({region: 'us-east-2'});
+AWSConfig.update({region: 'us-east-2'});
 
 // Create EC2 service object
-var ec2 = new AWS.EC2();
+var ec2 = new EC2();
 
 // Gaming server EC2 instance ID
 const gamingEC2ID = "i-0c794562f3be7c6f8";
@@ -26,7 +32,7 @@ let minecraftServerUp = false;
 /* FUNCTION: CHANGE MINECRAFT LEVEL / WORLD     */
 /* ============================================ */
 
-exports.changeLevelName = async (msg, levelName) => {
+export const changeLevelName = async (msg, levelName) => {
 
     // Get the most recent instance info
     let instancesInfo = await getEC2Info();
@@ -63,7 +69,7 @@ exports.changeLevelName = async (msg, levelName) => {
 
 // -----------------------------
 // Function: Add IPV6 to security group ingress rules
-exports.addIPV6 = (msg, ipv6, description) => {
+export const addIPV6 = (msg, ipv6, description) => {
 
     // Parameters for the new ingress rule
     var params = {
@@ -89,7 +95,7 @@ exports.addIPV6 = (msg, ipv6, description) => {
 
 // -----------------------------
 // Function: Add IPV4 to security group ingress rules
-exports.addIPV4 = (msg, ipv4, description) => {
+export const addIPV4 = (msg, ipv4, description) => {
 
     // Parameters for the new ingress rule
     var params = {
@@ -117,7 +123,7 @@ exports.addIPV4 = (msg, ipv4, description) => {
 /* FUNCTION: GET INSTANCES FROM EC2             */
 /* ============================================ */
 
-const getEC2Info = async () => {
+export const getEC2Info = async () => {
 
     // Variable to store the status of all instances
     let instancesInfo: Array<EC2Instance> = [];
@@ -155,12 +161,10 @@ const getEC2Info = async () => {
     return instancesInfo;
 }
 
-exports.getEC2Info = getEC2Info;
-
 
 // -----------------------------
 // Function: Stop the minecraft server
-exports.stopServer = async (msg) => {
+export const stopServer = async (msg) => {
 
     // Get the most recent instance info
     let instancesInfo = await getEC2Info();
@@ -212,7 +216,7 @@ exports.stopServer = async (msg) => {
 
 // -----------------------------
 // Function: Stop the EC2 instance
-exports.stopEC2Instance = async (msg) => {
+export const stopEC2Instance = async (msg) => {
 
     // EC2 parameters:
     // - InstanceIds: List with the IDs of all the EC2 instances to start
@@ -259,7 +263,7 @@ exports.stopEC2Instance = async (msg) => {
 
 // -----------------------------
 // Function: Start the EC2 server
-exports.startServer = async (msgChannel) => {
+export const startServer = async (msgChannel) => {
 
     // First discord message
     const msg = await msgChannel.send("Starting Server: ------- ");
@@ -377,7 +381,7 @@ exports.startServer = async (msgChannel) => {
 
 // -----------------------------
 // Function: Send SSH commands to instance
-const sendSSHCommands = async (cmds, hostIPV4, stopString, callback) => {
+export const sendSSHCommands = async (cmds, hostIPV4, stopString, callback) => {
 
     // Create connection object
     const conn = new sshClient();
@@ -438,12 +442,9 @@ const sendSSHCommands = async (cmds, hostIPV4, stopString, callback) => {
 
 }
 
-exports.sendSSHCommands = sendSSHCommands;
-
-
 // -----------------------------
 // Function: Retrieve the minecraft server status
-exports.getServerStatus = async () => {
+export const getServerStatus = async () => {
 
     // Default minecraft server status flag
     let minecraftServerUp = false;

--- a/src/customTypes.ts
+++ b/src/customTypes.ts
@@ -15,7 +15,7 @@
  * @property {string} name 
  * Name / label that the user assigned to the EC2 instance 
  * 
- * @property {"running" | "stopped" | "terminated"} status
+ * @property {string | "running" | "stopped" | "terminated"} status
  * Status of the EC2 instance. Possible values are: running, stopped
  * and terminated (more are available but I didn't include them)
  * 
@@ -28,7 +28,7 @@
 export type EC2Instance = {
     id: string,
     name: string,
-    status: "running" | "stopped" | "terminated",
+    status: string | "running" | "stopped" | "terminated",
     ipv4: string,
     ipv6: string
 }

--- a/src/databaseUtils.ts
+++ b/src/databaseUtils.ts
@@ -1,0 +1,41 @@
+import { Client as PostgresClient, QueryResult } from "pg"; 
+import * as dotenv from "dotenv";
+
+
+/* ============================================ */
+/* SETUP                                        */
+/* ============================================ */
+
+// Import the .env environment variables 
+dotenv.config({path: `${__dirname}/.env`});
+
+
+/* ============================================ */
+/* CONNECT TO THE DATABASE                      */
+/* ============================================ */
+
+export const connectDB = async () => {
+
+    /* ============== TRY TO CONNECT ============== */
+    try {
+
+        // Instantiate the client
+        const client = new PostgresClient({
+            user: process.env.DB_USER,
+            host: process.env.DB_HOST,
+            database: process.env.DB_NAME,
+            password: process.env.DB_PASS,
+            port: Number(process.env.DB_PORT)
+        });
+ 
+        await client.connect();
+        const res: QueryResult = await client.query('SELECT * FROM bot_info');
+        console.log("Connected to the database successfully: ", res.rows[0]);
+        await client.end();
+    } 
+
+    /* =============== CATCH ERRORS =============== */
+    catch (error) {
+        console.log(error);
+    }
+}


### PR DESCRIPTION
One of the biggest weaknesses of the discord bot currently is the fact that the state of the servers that the bot controls, are stored in the file itself. This means that, if the bot crashes for any reason the state of the servers will be reset to its initial value. To not have this problem I added a simple database container that's meant to store data regularly used by the bot, like the servers that it controls and other internal variables. For this I had to introduce a couple of changes:
- Included some initial data for the database, including a simple table with the status of the bot itself
- Changed the previously used "require" syntax for dependency management to the "import from" and "export" syntax
- Added a new type to the "status" variable, so that it can consist of also a generic string. Just a workaround for now, since I still need to revamp the types used for the bot.
- Included a new "databaseUtils" file that will allow the bot to contact the database and fetch data from it.
- Added some types to the discord related variables found in bot.ts
- Added a postgres container running on port 5432. Exposed the port to help with debugging when running the bot locally
- Installed types for the "cron" and "pg" (postgres) modules